### PR TITLE
Use node 9.x per #57

### DIFF
--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -10,8 +10,8 @@
   apt_repository: repo='{{ item }}'
                   state=present
   with_items:
-    - 'deb https://deb.nodesource.com/node_5.x {{ node_ubuntu_distro }} main'
-    - 'deb-src https://deb.nodesource.com/node_5.x {{ node_ubuntu_distro }} main'
+    - 'deb https://deb.nodesource.com/node_9.x {{ node_ubuntu_distro }} main'
+    - 'deb-src https://deb.nodesource.com/node_9.x {{ node_ubuntu_distro }} main'
   tags: nodejs
 
 - name: NodeJS | Yarn | Add apt key


### PR DESCRIPTION
Upgrading to node version 9 so butler can run in the vm. See https://github.com/palantirnet/butler/pull/100