### PR TITLE
Update D8 Solr config

### DIFF
--- a/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/schema.xml
+++ b/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/schema.xml
@@ -49,7 +49,7 @@
     that avoids logging every request
 -->
 
-<schema name="drupal-8.3.8-solr-7.x" version="1.6">
+<schema name="drupal-4.1.0-solr-7.x-0" version="1.6">
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
        version="x.y" is Solr's version number for the schema syntax and
        semantics.  It should not normally be changed by applications.

--- a/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/solrconfig.xml
+++ b/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/solrconfig.xml
@@ -11,7 +11,7 @@
      For more details about configurations options that may appear in
      this file, see http://wiki.apache.org/solr/SolrConfigXml.
 -->
-<config name="drupal-8.3.8-solr-7.x" >
+<config name="drupal-4.1.0-solr-7.x-0" >
   <!-- In all configuration below, a prefix of "solr." for class names
        is an alias that causes solr to search appropriate packages,
        including org.apache.solr.(search|update|request|core|analysis)

--- a/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/solrcore.properties
+++ b/provisioning/roles/solr-configuration/templates/solr_7.x_config-drupal8/solrcore.properties
@@ -4,11 +4,10 @@ solr.replication.pollInterval=00:00:60
 solr.replication.masterUrl=http://localhost:8983/solr
 solr.replication.confFiles=schema.xml,schema_extra_types.xml,schema_extra_fields.xml,elevate.xml,stopwords_en.txt,synonyms_en.txt,protwords_en.txt,accents_en.txt,stopwords_und.txt,synonyms_und.txt,protwords_und.txt,accents_und.txt
 solr.mlt.timeAllowed=2000
-solr.luceneMatchVersion=7.0
 solr.selectSearchHandler.timeAllowed=-1
 solr.autoCommit.MaxDocs=-1
 solr.autoCommit.MaxTime=15000
 solr.autoSoftCommit.MaxDocs=-1
 solr.autoSoftCommit.MaxTime=-1
-# Do not set install.dir. https://www.drupal.org/project/search_api_solr/issues/3015993
-#solr.install.dir=../../..
+
+solr.luceneMatchVersion=7.7


### PR DESCRIPTION
Using the latest box with Solr 7, we were receiving the following error:
`You are using outdated Solr configuration set. Please follow the instructions described in the README.md file for setting up Solr.`

Downloading and extracting the config from the site's `Get config.zip` link solved the error message, and search still appeared to work correctly.